### PR TITLE
feat: fetch admin stories from Strapi

### DIFF
--- a/apps/frontend/src/components/admin/ArticleEditor.tsx
+++ b/apps/frontend/src/components/admin/ArticleEditor.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Story, StoryPanelData } from '@/types/story';
-import { sampleStories } from '@/data/sampleStories';
+import { useStory } from '@/hooks/useStory';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 
 interface ArticleEditorProps {
@@ -20,10 +20,10 @@ export const ArticleEditor = ({ articleId, onBack }: ArticleEditorProps) => {
   const [article, setArticle] = useState<Story | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [newTag, setNewTag] = useState('');
+  const { data: existingArticle } = useStory(articleId || '');
 
   useEffect(() => {
     if (articleId) {
-      const existingArticle = sampleStories.find(s => s.id === articleId);
       if (existingArticle) {
         setArticle(existingArticle);
       }
@@ -45,7 +45,7 @@ export const ArticleEditor = ({ articleId, onBack }: ArticleEditorProps) => {
         panels: []
       });
     }
-  }, [articleId]);
+  }, [articleId, existingArticle]);
 
   const handleSave = async () => {
     if (!article) return;

--- a/apps/frontend/src/components/admin/ArticlesList.tsx
+++ b/apps/frontend/src/components/admin/ArticlesList.tsx
@@ -4,16 +4,22 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Edit, MapPin, Eye } from 'lucide-react';
+import { useAdminStories } from '@/hooks/useAdminStories';
 
 interface ArticlesListProps {
-  articles: Story[];
   onEditArticle: (articleId: string) => void;
 }
 
-export const ArticlesList = ({ articles, onEditArticle }: ArticlesListProps) => {
+export const ArticlesList = ({ onEditArticle }: ArticlesListProps) => {
+  const { data: articles = [], isLoading } = useAdminStories();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div className="grid gap-4">
-      {articles.map((article) => (
+      {articles.map((article: Story) => (
         <Card key={article.id} className="hover:shadow-md transition-shadow">
           <CardContent className="p-6">
             <div className="flex gap-4">

--- a/apps/frontend/src/hooks/useAdminStories.ts
+++ b/apps/frontend/src/hooks/useAdminStories.ts
@@ -1,0 +1,99 @@
+import { useQuery } from '@tanstack/react-query';
+import { strapiFetch, STRAPI_URL } from '@/integrations/strapi/client';
+import { Story, StoryPanelData } from '@/types/story';
+
+function getMediaUrl(file: any): string | undefined {
+  if (!file) return undefined;
+  if (typeof file === 'string') {
+    return `${STRAPI_URL}/uploads/${file}`;
+  }
+  if (file.data?.attributes?.url) {
+    return `${STRAPI_URL}${file.data.attributes.url}`;
+  }
+  if (file.url) {
+    return `${STRAPI_URL}${file.url}`;
+  }
+  return undefined;
+}
+
+export const useAdminStories = () => {
+  return useQuery({
+    queryKey: ['admin-stories'],
+    queryFn: async (): Promise<Story[]> => {
+      const response = await strapiFetch<any>(
+        '/api/articles',
+        'populate=author,cover,blocks,blocks.file,blocks.files'
+      );
+      const articles = response.data;
+
+      return articles.map((article: any) => {
+        const attrs = article.attributes;
+        const panels: StoryPanelData[] = [];
+
+        (attrs.blocks || []).forEach((block: any, index: number) => {
+          switch (block.__component) {
+            case 'shared.rich-text':
+              panels.push({
+                id: `${article.id}-rich-${index}`,
+                type: 'text',
+                content: block.body,
+                orderIndex: index,
+              });
+              break;
+            case 'shared.quote':
+              panels.push({
+                id: `${article.id}-quote-${index}`,
+                type: 'quote',
+                title: block.title,
+                content: block.body,
+                orderIndex: index,
+              });
+              break;
+            case 'shared.media':
+              panels.push({
+                id: `${article.id}-media-${index}`,
+                type: 'image',
+                media: getMediaUrl(block.file),
+                orderIndex: index,
+              });
+              break;
+            case 'shared.slider':
+              (block.files || []).forEach((file: any, fileIndex: number) => {
+                panels.push({
+                  id: `${article.id}-slider-${index}-${fileIndex}`,
+                  type: 'image',
+                  media: getMediaUrl(file),
+                  orderIndex: index + fileIndex / 100,
+                });
+              });
+              break;
+          }
+        });
+
+        const imagePanel = panels.find(p => p.type === 'image');
+
+        return {
+          id: article.id.toString(),
+          title: attrs.title,
+          author: attrs.author?.data?.attributes?.name || '',
+          subtitle: undefined,
+          handle: attrs.slug,
+          publishedAt: attrs.publishedAt || attrs.createdAt,
+          panels,
+          thumbnail: attrs.cover?.data?.attributes?.url
+            ? `${STRAPI_URL}${attrs.cover.data.attributes.url}`
+            : imagePanel?.media,
+          thumbnailPanelId: imagePanel?.id,
+          tags: undefined,
+          address: undefined,
+          description: attrs.description,
+          geo:
+            attrs.latitude && attrs.longitude
+              ? { lat: Number(attrs.latitude), lng: Number(attrs.longitude) }
+              : undefined,
+        } as Story;
+      });
+    },
+  });
+};
+

--- a/apps/frontend/src/pages/AdminDashboard.tsx
+++ b/apps/frontend/src/pages/AdminDashboard.tsx
@@ -1,21 +1,46 @@
 
+import { useState } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArticlesList } from '@/components/admin/ArticlesList';
+import { ArticleEditor } from '@/components/admin/ArticleEditor';
+import { useAdminStories } from '@/hooks/useAdminStories';
 
 const AdminDashboard = () => {
+  const [editingArticleId, setEditingArticleId] = useState<string | null>(null);
+  const { data: articles = [] } = useAdminStories();
+
+  if (editingArticleId !== null) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6">
+          <ArticleEditor articleId={editingArticleId || null} onBack={() => setEditingArticleId(null)} />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-4xl mx-auto p-6">
         {/* Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Content Management</h1>
-          <p className="text-gray-600">Manage your stories and content through Strapi CMS</p>
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">Content Management</h1>
+            <p className="text-gray-600">Manage your stories and content through Strapi CMS</p>
+            <p className="text-sm text-gray-500">{articles.length} articles</p>
+          </div>
+          <Button onClick={() => setEditingArticleId('')} className="flex items-center gap-2">
+            Create Article
+          </Button>
         </div>
 
+        {/* Articles List */}
+        <ArticlesList onEditArticle={setEditingArticleId} />
+
         {/* Strapi Dashboard Link */}
-        <Card>
+        <Card className="mt-6">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <ExternalLink size={20} />
@@ -27,7 +52,7 @@ const AdminDashboard = () => {
               <p className="text-gray-600">
                 Access your Strapi dashboard to create and manage stories, upload media, and configure content.
               </p>
-              <Button 
+              <Button
                 onClick={() => window.open('http://localhost:1337/admin', '_blank')}
                 className="flex items-center gap-2"
               >
@@ -54,7 +79,7 @@ const AdminDashboard = () => {
           </CardHeader>
           <CardContent>
             <p className="text-gray-600 mb-4">
-              Your current database is already compatible with Strapi. The existing tables (stories, story_panels) 
+              Your current database is already compatible with Strapi. The existing tables (stories, story_panels)
               follow Strapi conventions and can be easily integrated.
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/apps/frontend/src/pages/AdminDashboard.tsx
+++ b/apps/frontend/src/pages/AdminDashboard.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArticlesList } from '@/components/admin/ArticlesList';
 import { ArticleEditor } from '@/components/admin/ArticleEditor';
 import { useAdminStories } from '@/hooks/useAdminStories';
+import { STRAPI_URL } from '@/integrations/strapi/client';
 
 const AdminDashboard = () => {
   const [editingArticleId, setEditingArticleId] = useState<string | null>(null);
@@ -53,7 +54,7 @@ const AdminDashboard = () => {
                 Access your Strapi dashboard to create and manage stories, upload media, and configure content.
               </p>
               <Button
-                onClick={() => window.open('http://localhost:1337/admin', '_blank')}
+                onClick={() => window.open(`${STRAPI_URL}/admin`, '_blank')}
                 className="flex items-center gap-2"
               >
                 <ExternalLink size={16} />

--- a/apps/frontend/src/pages/AdminDashboard.tsx
+++ b/apps/frontend/src/pages/AdminDashboard.tsx
@@ -11,6 +11,7 @@ import { STRAPI_URL } from '@/integrations/strapi/client';
 const AdminDashboard = () => {
   const [editingArticleId, setEditingArticleId] = useState<string | null>(null);
   const { data: articles = [] } = useAdminStories();
+  const openStrapiDashboard = () => window.open(`${STRAPI_URL}/admin`, '_blank');
 
   if (editingArticleId !== null) {
     return (
@@ -54,7 +55,7 @@ const AdminDashboard = () => {
                 Access your Strapi dashboard to create and manage stories, upload media, and configure content.
               </p>
               <Button
-                onClick={() => window.open(`${STRAPI_URL}/admin`, '_blank')}
+                onClick={openStrapiDashboard}
                 className="flex items-center gap-2"
               >
                 <ExternalLink size={16} />


### PR DESCRIPTION
## Summary
- add `useAdminStories` hook that retrieves articles from Strapi
- replace `sampleStories` with live data in admin components
- integrate article list and editor in admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: could not resolve dependency react@^19.0.0 for react-leaflet@5.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689e6805dca88320ad105736925b8387