### PR TITLE
Fix docker-compose configuration for Strapi and Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,39 @@
-services:
-api:
-build: ./apps/backend # requires a Dockerfile in apps/backend
-env_file: ./apps/backend/.env
-ports: ["8000:8000"]
-volumes:
-- ./apps/backend:/app
-command: sh -c "uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+version: '3.8'
 
-web:
-build: ./apps/frontend # requires a Dockerfile in apps/frontend
-env_file: ./apps/frontend/.env.local
-ports: ["3000:3000"]
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: strapi
+      POSTGRES_PASSWORD: strapi
+      POSTGRES_DB: strapi
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  api:
+    build: ./apps/backend
+    env_file: ./apps/backend/.env
+    ports:
+      - "1337:1337"
+    volumes:
+      - ./apps/backend:/app
+    depends_on:
+      - postgres
+    command: npm run develop
+
+  web:
+    build: ./apps/frontend
+    env_file: ./apps/frontend/.env.local
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./apps/frontend:/app
+    depends_on:
+      - api
+
 volumes:
-- ./apps/frontend:/app
-depends_on:
-- api
+  postgres_data:
+


### PR DESCRIPTION
## Summary
- Rewrite docker-compose.yml with proper indentation
- Add postgres service and update api to run Strapi dev server on port 1337
- Include volume declaration for persistent database storage

## Testing
- `npm test` (backend, fails: Missing script)
- `npm test` (frontend, fails: Missing script)
- `docker compose config` (fails: command not found)
- `apt-get update` (fails: repository not signed / 403)


------
https://chatgpt.com/codex/tasks/task_e_689efd5b3174832086163d942f8be873