### PR TITLE
chore: update postgres port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
 
   api:
     build: ./apps/backend


### PR DESCRIPTION
## Summary
- change Postgres port binding to use host port 5433

## Testing
- `docker compose config` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b5fe7c7c832092fe36f02ceedea9