### PR TITLE
chore: convert env example to key value pairs

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,59 +1,38 @@
-diff --git a/.env.example b/.env.example
-index 51bf23e850ad0e0a6b78fac3d9d9d7f4a1e2c062..1fd814ec802c1f522494ac20dc17fcdac64b0262 100644
---- a/.env.example
-+++ b/.env.example
-@@ -1,21 +1,39 @@
- 
- # Server
--HOST=
--PORT=
-+# Host interface the server binds to (use 0.0.0.0 for Docker)
-+HOST=0.0.0.0
-+# HTTP port the server listens on
-+PORT=1337
-+# URL of the frontend application (used for CORS)
-+FRONTEND_URL=http://localhost:3000
- 
- # Secrets
--APP_KEYS=
--API_TOKEN_SALT=
--ADMIN_JWT_SECRET=
--TRANSFER_TOKEN_SALT=
-+# Comma-separated keys for signing cookies
-+APP_KEYS=appKey1,appKey2
-+# Salt used when generating API tokens
-+API_TOKEN_SALT=apiTokenSalt
-+# Secret used to sign admin JWTs
-+ADMIN_JWT_SECRET=adminJwtSecret
-+# Salt for transfer token generation
-+TRANSFER_TOKEN_SALT=transferTokenSalt
- 
- # Database
--DATABASE_CLIENT=
--DATABASE_HOST=
--DATABASE_PORT=
--DATABASE_NAME=
--DATABASE_USERNAME=
--DATABASE_PASSWORD=
--DATABASE_SSL=
--DATABASE_FILENAME=
--JWT_SECRET=
-+# Database client to use (e.g. postgres, mysql, sqlite)
-+DATABASE_CLIENT=postgres
-+# Database host; in Docker, use the service name (e.g. "postgres")
-+DATABASE_HOST=postgres
-+# Database port
-+DATABASE_PORT=5432
-+# Name of the database
-+DATABASE_NAME=strapi
-+# Username for the database connection
-+DATABASE_USERNAME=strapi
-+# Password for the database connection
-+DATABASE_PASSWORD=strapi
-+# Enable SSL connection (set to true in production)
-+DATABASE_SSL=false
-+# SQLite file path (only used when DATABASE_CLIENT=sqlite)
-+DATABASE_FILENAME=.tmp/data.db
-+
-+# Secret used to sign user JWTs
-+JWT_SECRET=jwtSecret
+# Server
+# Host interface the server binds to (use 0.0.0.0 for Docker)
+HOST=0.0.0.0
+# HTTP port the server listens on
+PORT=1337
+# URL of the frontend application (used for CORS)
+FRONTEND_URL=http://localhost:3000
+
+# Secrets
+# Comma-separated keys for signing cookies
+APP_KEYS=appKey1,appKey2
+# Salt used when generating API tokens
+API_TOKEN_SALT=apiTokenSalt
+# Secret used to sign admin JWTs
+ADMIN_JWT_SECRET=adminJwtSecret
+# Salt for transfer token generation
+TRANSFER_TOKEN_SALT=transferTokenSalt
+
+# Database
+# Database client to use (e.g. postgres, mysql, sqlite)
+DATABASE_CLIENT=postgres
+# Database host; in Docker, use the service name (e.g. "postgres")
+DATABASE_HOST=postgres
+# Database port
+DATABASE_PORT=5432
+# Name of the database
+DATABASE_NAME=strapi
+# Username for the database connection
+DATABASE_USERNAME=strapi
+# Password for the database connection
+DATABASE_PASSWORD=strapi
+# Enable SSL connection (set to true in production)
+DATABASE_SSL=false
+# SQLite file path (only used when DATABASE_CLIENT=sqlite)
+DATABASE_FILENAME=.tmp/data.db
+
+# Secret used to sign user JWTs
+JWT_SECRET=jwtSecret


### PR DESCRIPTION
## Summary
- rewrite backend `.env.example` with straightforward `KEY=value` pairs and helpful comments

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a1b60692748320964d7d4e6798a1c0