### PR TITLE
fix: mount backend in correct container path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - "1337:1337"
     volumes:
-      - ./apps/backend:/app
+      - ./apps/backend:/opt/app
     depends_on:
       - postgres
     command: npm run develop


### PR DESCRIPTION
## Summary
- mount backend source at `/opt/app` in docker compose to match container WORKDIR

## Testing
- `docker compose config` *(fails: command not found)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b60164e08320b32c78907c16de61