### PR TITLE
feat: add frontend dockerfile

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Multi-stage Dockerfile for frontend
+
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Run stage
+FROM node:20-alpine AS run
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     command: npm run develop
 
   web:
-    build: ./apps/frontend
+    build:
+      context: ./apps/frontend
+      dockerfile: Dockerfile
     env_file: ./apps/frontend/.env.local
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- add multistage Dockerfile for frontend app
- point docker-compose web service at new Dockerfile

## Testing
- `npm run build` *(fails: vite: not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b604195c83209309817451de9755