### PR TITLE
feat: extend uploads caching

### DIFF
--- a/apps/nginx/nginx.conf
+++ b/apps/nginx/nginx.conf
@@ -13,6 +13,9 @@
     server proxy:4000;
   }
 
+  # Optional disk cache for media files; uncomment and adjust path/size as needed
+  # proxy_cache_path /var/cache/nginx/uploads levels=1:2 keys_zone=uploads_cache:10m max_size=1g inactive=30d use_temp_path=off;
+
   server {
     listen 80;
     server_name _;
@@ -100,9 +103,13 @@
 
     # Media files – proxy directly to Strapi (public files)
     location /uploads/ {
-      # Cache static media a bit at the edge
-      expires 1h;
-      add_header Cache-Control "public";
+      # Cache static media longer at the edge
+      expires 30d;
+      add_header Cache-Control "public, max-age=2592000";
+
+      # Optional caching; remove comments and ensure proxy_cache_path is configured above
+      # proxy_cache uploads_cache;
+      # proxy_cache_valid 200 30d;
 
       proxy_http_version 1.1;
       proxy_set_header Connection "";


### PR DESCRIPTION
## Summary
- extend cache duration for `/uploads/` assets and expose explicit Cache-Control header
- add optional proxy cache configuration for media files

## Testing
- `npm test` (fails: Missing script "test")
- `nginx -t -c $(pwd)/apps/nginx/nginx.conf` (fails: command not found)
- `apt-get update` (fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_68b300513ff88320a6d4b74497f9d730